### PR TITLE
Update from 20.4.6 to 20.16.2

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+channels:
+  mesters_org: anaconda-linter

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,0 @@
-channels:
-  mesters_org: anaconda-linter

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -26,7 +26,6 @@ requirements:
     - wheel >=0.30.0
   run:
     - python
-    - appdirs >=1.4.3,<2
     - distlib >=0.3.1,<1
     - filelock >=3.2,<4
     - importlib-metadata >=0.12  # [py<38]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: 0ef5be6d07181946891f5abc8047fda8bc2f0b4b9bf222c64e6e8963baee76db
 
 build:
-  number: 1
+  number: 0
   skip: true  # [py<34]
   script: {{ PYTHON }} -m pip install . -vv
   entry_points:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -36,6 +36,13 @@ test:
   imports:
     - virtualenv
     - virtualenv.activation
+    - virtualenv.app_data
+    - virtualenv.config
+    - virtualenv.create
+    - virtualenv.discovery
+    - virtualenv.run
+    - virtualenv.seed
+    - virtualenv.util
   commands:
     - pip check
     - virtualenv --help

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
 
 build:
   number: 0
-  skip: true  # [py<34]
+  skip: true  # [py<36]
   script: {{ PYTHON }} -m pip install . -vv
   entry_points:
     - virtualenv = virtualenv.__main__:run_with_catch

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,7 +20,7 @@ requirements:
     - python                                 # [build_platform != target_platform]
   host:
     - python
-    - pip >=18
+    - pip
     - setuptools >=41.0.0
     - setuptools_scm >=2
     - wheel >=0.30.0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -45,6 +45,7 @@ test:
 about:
   home: https://virtualenv.pypa.io/
   license: MIT
+  license_family: MIT
   license_file: LICENSE
   summary: Virtual Python Environment builder
   description: |

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "20.4.6" %}
+{% set version = "20.16.2" %}
 
 package:
   name: virtualenv
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/v/virtualenv/virtualenv-{{ version }}.tar.gz
-  sha256: 72cf267afc04bf9c86ec932329b7e94db6a0331ae9847576daaa7ca3c86b29a4
+  sha256: 0ef5be6d07181946891f5abc8047fda8bc2f0b4b9bf222c64e6e8963baee76db
 
 build:
   number: 1
@@ -21,17 +21,17 @@ requirements:
   host:
     - python
     - pip >=18
-    - setuptools >=41
+    - setuptools >=41.0.0
     - setuptools_scm >=2
+    - wheel >=0.30.0
   run:
     - python
     - appdirs >=1.4.3,<2
     - distlib >=0.3.1,<1
-    - filelock >=3.0.0,<4
+    - filelock >=3.2,<4
     - importlib-metadata >=0.12  # [py<38]
     - importlib_resources >=1.0  # [py<37]
-    - pathlib2 >=2.3.3,<3  # [py<34 and not win]
-    - six >=1.9.0,<2   # keep it >=1.9.0 as it may cause problems on LTS platforms
+    - platformdirs >=2,<3
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -50,7 +50,7 @@ about:
   summary: Virtual Python Environment builder
   description: |
     A tool for creating isolated virtual python environments.
-  doc_url: https://virtualenv.pypa.io/en/latest/
+  doc_url: https://virtualenv.pypa.io/
   dev_url: https://github.com/pypa/virtualenv
 
 extra:


### PR DESCRIPTION
anaconda-linter needs at least v20.10.0. This version is the latest version that does not require additional dependency updates.

# Package info

Home: https://virtualenv.pypa.io/
Doc: https://virtualenv.pypa.io/
Dev: https://github.com/pypa/virtualenv
Change log: https://github.com/pypa/virtualenv/compare/20.4.6...20.16.2