### PR TITLE
virtualenv 20.26.1

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,0 @@
-channels:
-  - https://staging.continuum.io/prefect/fs/distlib-feedstock/pr5/bc27fc5

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+channels:
+  - https://staging.continuum.io/prefect/fs/distlib-feedstock/pr5/bc27fc5

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,7 +1,7 @@
 {% set name = "virtualenv" %}
-{% set version = "20.17.1" %}
-{% set checksum = "f8b927684efc6f1cc206c9db297a570ab9ad0e51c16fa9e45487d36d1905c058" %}
-{% set build = "0" %}
+{% set version = "20.26.1" %}
+{% set checksum = "604bfdceaeece392802e6ae48e69cec49168b9c5f4a44e483963f9242eb0e78b" %}
+{% set build = 0 %}
 
 package:
   name: {{ name }}
@@ -12,10 +12,9 @@ source:
   sha256: {{ checksum }}
 
 build:
-  # trigger 1
   number: {{ build }}
-  skip: True  # [py<36]
-  script: {{ PYTHON }} -m pip install . -vv --no-deps
+  skip: True  # [py<37]
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
   entry_points:
     - virtualenv = virtualenv.__main__:run_with_catch
 
@@ -23,16 +22,13 @@ requirements:
   host:
     - python
     - pip
-    - setuptools
-    - setuptools_scm
-    - wheel
+    - hatch-vcs >=0.3
+    - hatchling >=1.17.1
   run:
     - python
-    - distlib >=0.3.6,<1
-    - filelock >=3.4.1,<4
-    - importlib-metadata >=4.8.3  # [py<38]
-    - importlib_resources >=5.4  # [py<37]
-    - platformdirs >=2.4,<3
+    - distlib <1,>=0.3.7
+    - filelock <4,>=3.12.2
+    - platformdirs <5,>=3.9.1
 
 test:
   # optional-dependencies.test can be found here if we want to add upstream tests down the line:


### PR DESCRIPTION
**Destination channel:** main

### Links

- [PKG-4627](https://anaconda.atlassian.net/browse/PKG-4627)
- release-notes-tagged: https://github.com/pypa/virtualenv/releases/tag/20.26.1
- release-diff: https://github.com/pypa/virtualenv/compare/20.17.1...20.26.1
- requirements-tagged:
  - https://github.com/pypa/virtualenv/blob/20.26.1/pyproject.toml


### Explanation of changes:

- Update the script by conda-lint --fix
- Update host and run dependencies

### Notes:

- It was noticed that the current version `20.17.1` doesn't support Python 3.12 because `pkgutil.ImpImporter` has been removed in v3.12.

[PKG-4627]: https://anaconda.atlassian.net/browse/PKG-4627?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ